### PR TITLE
Support the "ovs-ofctl dump-ports-desc".

### DIFF
--- a/ovs/openflow.go
+++ b/ovs/openflow.go
@@ -339,11 +339,13 @@ func (o *OpenFlowService) describePorts(bridge string) ([]*PortDesc, error) {
 	err = parseEachLine(out, dumpPortsDescPrefix, func(b []byte) error {
 		s := new(PortDesc)
 		if err := s.UnmarshalText(b); err != nil {
-			return err
+			if err == ErrIgnoreUnusedDesc {
+				return nil
+			} else {
+				return err
+			}
 		}
-		if s.Name != "" {
-			descs = append(descs, s)
-		}
+		descs = append(descs, s)
 		return nil
 	})
 

--- a/ovs/openflow.go
+++ b/ovs/openflow.go
@@ -341,9 +341,8 @@ func (o *OpenFlowService) describePorts(bridge string) ([]*PortDesc, error) {
 		if err := s.UnmarshalText(b); err != nil {
 			if err == ErrIgnoreUnusedDesc {
 				return nil
-			} else {
-				return err
 			}
+			return err
 		}
 		descs = append(descs, s)
 		return nil

--- a/ovs/portdesc.go
+++ b/ovs/portdesc.go
@@ -25,7 +25,7 @@ var (
 	// dump-ports' do not match the expected output format.
 	ErrInvalidPortDesc = errors.New("invalid port description")
 
-	// Skip
+	// ErrIgnoreUnusedDesc is returned when the current input isn't what we want
 	ErrIgnoreUnusedDesc = errors.New("Ingore unused port description")
 )
 

--- a/ovs/portdesc.go
+++ b/ovs/portdesc.go
@@ -1,0 +1,77 @@
+// Copyright 2017 DigitalOcean.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ovs
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+)
+
+var (
+	// ErrInvalidPortDesc is returned when port statistics from 'ovs-ofctl
+	// dump-ports' do not match the expected output format.
+	ErrInvalidPortDesc = errors.New("invalid port description")
+)
+
+// PortDesc contains a variety of statistics about an Open vSwitch port,
+// including its port ID and numbers about packet receive and transmit
+// operations.
+type PortDesc struct {
+	// PortID specifies the OVS port ID which this PortDesc refers to.
+	ID   int32
+	Name string
+
+	MACAddress string
+}
+
+// UnmarshalText unmarshals a PortDesc from textual form as output by
+// 'ovs-ofctl dump-ports-desc':
+// LOCAL(mybr0): addr:1a:e4:7d:9c:72:45
+//   config:     PORT_DOWN
+//   state:      LINK_DOWN
+//   current: 10GB-FD COPPER
+//   speed: 0 Mbps now, 0 Mbps max
+func (p *PortDesc) UnmarshalText(b []byte) error {
+	// Make a copy per documentation for encoding.TextUnmarshaler.
+	s := string(b)
+
+	// Constants only needed within this method, to avoid polluting the
+	// package namespace with generic names
+	ss := strings.Fields(s)
+
+	addr := ss[1]
+	if len(addr) != 22 || addr[0:4] != "addr" {
+		return nil
+	}
+
+	//We only parse the ID/Name/MAC now.
+	left := strings.IndexByte(ss[0], '(')
+	right := strings.IndexByte(ss[0], ')')
+	p.Name = ss[0][left+1 : right]
+
+	//Name
+	p.MACAddress = ss[1][5:]
+
+	//ID
+	id := ss[0][0:left]
+	if id == "LOCAL" {
+		p.ID = -1
+	} else {
+		tmp, _ := strconv.Atoi(id)
+		p.ID = (int32)(tmp)
+	}
+	return nil
+}

--- a/ovs/portdesc_test.go
+++ b/ovs/portdesc_test.go
@@ -1,0 +1,68 @@
+// Copyright 2017 DigitalOcean.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ovs
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPortDescUnmarshalText(t *testing.T) {
+	var tests = []struct {
+		desc string
+		s    string
+		p    *PortDesc
+		err  error
+	}{
+		{
+			desc: "empty string",
+			err:  ErrInvalidPortDesc,
+		},
+		{
+			desc: "Unused config",
+			s:    "config:     PORT_DOWN",
+			err:  ErrIgnoreUnusedDesc,
+		},
+		{
+			desc: "OK",
+			s:    "LOCAL(mybr0): addr:1a:e4:7d:9c:72:45",
+			p: &PortDesc{
+				ID:         PortLOCAL,
+				Name:       "mybr0",
+				MACAddress: "1a:e4:7d:9c:72:45",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			p := new(PortDesc)
+			err := p.UnmarshalText([]byte(tt.s))
+
+			if want, got := errStr(tt.err), errStr(err); want != got {
+				t.Fatalf("unexpected error:\n- want: %v\n-  got: %v",
+					want, got)
+			}
+			if err != nil {
+				return
+			}
+
+			if want, got := tt.p, p; !reflect.DeepEqual(want, got) {
+				t.Fatalf("unexpected PortDesc:\n- want: %#v\n-  got: %#v",
+					want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Support the new command, dump-ports-desc and we only parse the ID/Name/MAC address now.
![screen shot 2018-08-24 at 4 32 39 pm](https://user-images.githubusercontent.com/1932305/44645100-00d22600-aa09-11e8-91d8-5e4fd7b36ad7.png)
